### PR TITLE
Update readme: Added Debian build section

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ Ubuntu
 sudo apt install build-essential git cmake g++-10 libssl-dev 
 ```
 
+Debian
+
+```shell
+sudo apt install build-essential git cmake g++-10 libssl-dev libtbb-dev
+```
+
 Fedora/RHEL/CentOS
 
 ```shell


### PR DESCRIPTION
Using Debian 11 with Ubuntu build instructions, without installing: libtbb-dev (by default it's not installed on debian)
Build fails with:

`-- Using cryptographic library: OpenSSL -- Could NOT find TBB (missing: TBB_DIR) CMake Error at cmake/FindTBB.cmake:142 (message): Required library TBB not found. Call Stack (most recent call first): cmake/FindTBB.cmake:378 (findpkg_finish) CMakeLists.txt:54 (find_package) `