### PR TITLE
Bencode external references incorrect tag

### DIFF
--- a/external/bencode.cmake
+++ b/external/bencode.cmake
@@ -23,7 +23,7 @@ else()
     FetchContent_Declare(
             bencode
             GIT_REPOSITORY https://github.com/fbdtemme/bencode.git
-            GIT_TAG        master
+            GIT_TAG        main
     )
     FetchContent_MakeAvailable(bencode)
 endif()


### PR DESCRIPTION
Tag changed from `master` to `main` on bencode repository. Update this cmake to pull correct tag.